### PR TITLE
update lwip to 0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "file-type": "^2.7.0",
     "gulp-util": "^3.0.5",
-    "lwip": "0.0.7",
+    "lwip": "0.0.8",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
lwip 0.0.8 adds support for the latest versions of Node.js (v4+). Please consider merging and releasing this change so that gulp-lwip can be used with Node v4+. Thank you.
